### PR TITLE
[IMP] account_invoice_mass_sending: add email layout and follower notifications for invoice mass sending

### DIFF
--- a/account_invoice_google_document_ai/i18n/ca.po
+++ b/account_invoice_google_document_ai/i18n/ca.po
@@ -1,0 +1,155 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_invoice_google_document_ai
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+#. module: account_invoice_google_document_ai
+#. odoo-python
+#: code:addons/account_invoice_google_document_ai/models/account_move_google_document_ai.py:0
+#, python-format
+msgid "%(field_name)s is not coincident (%(value1)s - %(value2)s)"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.res_config_settings_form_view
+msgid ""
+"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
+"specific.\" aria-label=\"Values set here are company-specific.\" "
+"groups=\"base.group_multi_company\" role=\"img\"/>"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.res_config_settings_form_view
+msgid ""
+"Access Google Cloud console, create an App, enable Google Document AI API "
+"and fill the following data"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model,name:account_invoice_google_document_ai.model_account_move_google_document_ai
+msgid "Account Move Google Document Ai Functions"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.res_config_settings_form_view
+msgid "Authentication"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_account_bank_statement_line__can_send_to_ocr
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_account_move__can_send_to_ocr
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_account_payment__can_send_to_ocr
+msgid "Can Send To Ocr"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model,name:account_invoice_google_document_ai.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model,name:account_invoice_google_document_ai.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields.selection,name:account_invoice_google_document_ai.selection__res_company__ocr_google_enabled__no_send
+msgid "Do not send invoices to google"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.res_config_settings_form_view
+msgid "Enable Google OCR for invoices"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields.selection,name:account_invoice_google_document_ai.selection__res_company__ocr_google_location__eu
+msgid "Europe"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model,name:account_invoice_google_document_ai.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.res_config_settings_form_view
+msgid "Location"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_company__ocr_google_authentication
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_config_settings__ocr_google_authentication
+msgid "Ocr Google Authentication"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_company__ocr_google_authentication_name
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_config_settings__ocr_google_authentication_name
+msgid "Ocr Google Authentication Name"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_company__ocr_google_enabled
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_config_settings__ocr_google_enabled
+msgid "Ocr Google Enabled"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_company__ocr_google_location
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_config_settings__ocr_google_location
+msgid "Ocr Google Location"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_company__ocr_google_processor
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_config_settings__ocr_google_processor
+msgid "Ocr Google Processor"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_company__ocr_google_project
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_config_settings__ocr_google_project
+msgid "Ocr Google Project"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields.selection,name:account_invoice_google_document_ai.selection__res_company__ocr_google_enabled__send_manual
+msgid "Only send invoices to google manually"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.res_config_settings_form_view
+msgid "Processor"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.res_config_settings_form_view
+msgid "Project"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields.selection,name:account_invoice_google_document_ai.selection__res_company__ocr_google_enabled__send_automatically
+msgid "Send invoices to google automatically"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.account_move_form_view
+msgid "Send to OCR"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields.selection,name:account_invoice_google_document_ai.selection__res_company__ocr_google_location__us
+msgid "United States"
+msgstr ""

--- a/account_invoice_google_document_ai/i18n/ca.po
+++ b/account_invoice_google_document_ai/i18n/ca.po
@@ -6,20 +6,22 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"Last-Translator: Automatically generated\n"
+"PO-Revision-Date: 2026-02-06 16:06+0000\n"
+"Last-Translator: Jonathan Pasquier <jpasquier@fundesplai.org>\n"
 "Language-Team: none\n"
 "Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.15.2\n"
 
 #. module: account_invoice_google_document_ai
 #. odoo-python
 #: code:addons/account_invoice_google_document_ai/models/account_move_google_document_ai.py:0
 #, python-format
 msgid "%(field_name)s is not coincident (%(value1)s - %(value2)s)"
-msgstr ""
+msgstr "%(field_name)s no coincideix amb (%(value1)s - %(value2)s)"
 
 #. module: account_invoice_google_document_ai
 #: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.res_config_settings_form_view
@@ -28,6 +30,10 @@ msgid ""
 "specific.\" aria-label=\"Values set here are company-specific.\" "
 "groups=\"base.group_multi_company\" role=\"img\"/>"
 msgstr ""
+"<span class=\"fa fa-lg fa-building-o\" title=\"Els valors indicats aquí són "
+"especifiques per la companyia.\" aria-label=\"Els valors indicats aquí són "
+"especifiques per la companyia.\" groups=\"base.group_multi_company\" "
+"role=\"img\"/>"
 
 #. module: account_invoice_google_document_ai
 #: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.res_config_settings_form_view
@@ -35,121 +41,123 @@ msgid ""
 "Access Google Cloud console, create an App, enable Google Document AI API "
 "and fill the following data"
 msgstr ""
+"Accedeix a la consola de Google Cloud, crea una aplicació, activa l'API de "
+"Document AI de Google i omple les dades següents"
 
 #. module: account_invoice_google_document_ai
 #: model:ir.model,name:account_invoice_google_document_ai.model_account_move_google_document_ai
 msgid "Account Move Google Document Ai Functions"
-msgstr ""
+msgstr "Funcions Google Document AI per a assentaments"
 
 #. module: account_invoice_google_document_ai
 #: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.res_config_settings_form_view
 msgid "Authentication"
-msgstr ""
+msgstr "Autenticació"
 
 #. module: account_invoice_google_document_ai
 #: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_account_bank_statement_line__can_send_to_ocr
 #: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_account_move__can_send_to_ocr
 #: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_account_payment__can_send_to_ocr
 msgid "Can Send To Ocr"
-msgstr ""
+msgstr "Pot enviar a OCR"
 
 #. module: account_invoice_google_document_ai
 #: model:ir.model,name:account_invoice_google_document_ai.model_res_company
 msgid "Companies"
-msgstr ""
+msgstr "Companyies"
 
 #. module: account_invoice_google_document_ai
 #: model:ir.model,name:account_invoice_google_document_ai.model_res_config_settings
 msgid "Config Settings"
-msgstr ""
+msgstr "Paràmetres de configuració"
 
 #. module: account_invoice_google_document_ai
 #: model:ir.model.fields.selection,name:account_invoice_google_document_ai.selection__res_company__ocr_google_enabled__no_send
 msgid "Do not send invoices to google"
-msgstr ""
+msgstr "No envieu factures a Google"
 
 #. module: account_invoice_google_document_ai
 #: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.res_config_settings_form_view
 msgid "Enable Google OCR for invoices"
-msgstr ""
+msgstr "Activa l'OCR de Google per a factures"
 
 #. module: account_invoice_google_document_ai
 #: model:ir.model.fields.selection,name:account_invoice_google_document_ai.selection__res_company__ocr_google_location__eu
 msgid "Europe"
-msgstr ""
+msgstr "Europa"
 
 #. module: account_invoice_google_document_ai
 #: model:ir.model,name:account_invoice_google_document_ai.model_account_move
 msgid "Journal Entry"
-msgstr ""
+msgstr "Assentament comptable"
 
 #. module: account_invoice_google_document_ai
 #: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.res_config_settings_form_view
 msgid "Location"
-msgstr ""
+msgstr "Ubicació"
 
 #. module: account_invoice_google_document_ai
 #: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_company__ocr_google_authentication
 #: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_config_settings__ocr_google_authentication
 msgid "Ocr Google Authentication"
-msgstr ""
+msgstr "Ocr Google - Autenticació"
 
 #. module: account_invoice_google_document_ai
 #: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_company__ocr_google_authentication_name
 #: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_config_settings__ocr_google_authentication_name
 msgid "Ocr Google Authentication Name"
-msgstr ""
+msgstr "Ocr Google - Nom d'autenticació"
 
 #. module: account_invoice_google_document_ai
 #: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_company__ocr_google_enabled
 #: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_config_settings__ocr_google_enabled
 msgid "Ocr Google Enabled"
-msgstr ""
+msgstr "Ocr Google - Habilitat"
 
 #. module: account_invoice_google_document_ai
 #: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_company__ocr_google_location
 #: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_config_settings__ocr_google_location
 msgid "Ocr Google Location"
-msgstr ""
+msgstr "Ocr Google - Ubicació"
 
 #. module: account_invoice_google_document_ai
 #: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_company__ocr_google_processor
 #: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_config_settings__ocr_google_processor
 msgid "Ocr Google Processor"
-msgstr ""
+msgstr "Ocr Google - Processador"
 
 #. module: account_invoice_google_document_ai
 #: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_company__ocr_google_project
 #: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_config_settings__ocr_google_project
 msgid "Ocr Google Project"
-msgstr ""
+msgstr "Ocr Google - Projecte"
 
 #. module: account_invoice_google_document_ai
 #: model:ir.model.fields.selection,name:account_invoice_google_document_ai.selection__res_company__ocr_google_enabled__send_manual
 msgid "Only send invoices to google manually"
-msgstr ""
+msgstr "Només enviar les factures a Google manualment."
 
 #. module: account_invoice_google_document_ai
 #: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.res_config_settings_form_view
 msgid "Processor"
-msgstr ""
+msgstr "Processador"
 
 #. module: account_invoice_google_document_ai
 #: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.res_config_settings_form_view
 msgid "Project"
-msgstr ""
+msgstr "Projecte"
 
 #. module: account_invoice_google_document_ai
 #: model:ir.model.fields.selection,name:account_invoice_google_document_ai.selection__res_company__ocr_google_enabled__send_automatically
 msgid "Send invoices to google automatically"
-msgstr ""
+msgstr "Enviar factures a Google automàticament"
 
 #. module: account_invoice_google_document_ai
 #: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.account_move_form_view
 msgid "Send to OCR"
-msgstr ""
+msgstr "Enviar a l'OCR"
 
 #. module: account_invoice_google_document_ai
 #: model:ir.model.fields.selection,name:account_invoice_google_document_ai.selection__res_company__ocr_google_location__us
 msgid "United States"
-msgstr ""
+msgstr "Estats Units"

--- a/account_invoice_google_document_ai/i18n/ca_ES.po
+++ b/account_invoice_google_document_ai/i18n/ca_ES.po
@@ -1,0 +1,155 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_invoice_google_document_ai
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ca_ES\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+#. module: account_invoice_google_document_ai
+#. odoo-python
+#: code:addons/account_invoice_google_document_ai/models/account_move_google_document_ai.py:0
+#, python-format
+msgid "%(field_name)s is not coincident (%(value1)s - %(value2)s)"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.res_config_settings_form_view
+msgid ""
+"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
+"specific.\" aria-label=\"Values set here are company-specific.\" "
+"groups=\"base.group_multi_company\" role=\"img\"/>"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.res_config_settings_form_view
+msgid ""
+"Access Google Cloud console, create an App, enable Google Document AI API "
+"and fill the following data"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model,name:account_invoice_google_document_ai.model_account_move_google_document_ai
+msgid "Account Move Google Document Ai Functions"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.res_config_settings_form_view
+msgid "Authentication"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_account_bank_statement_line__can_send_to_ocr
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_account_move__can_send_to_ocr
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_account_payment__can_send_to_ocr
+msgid "Can Send To Ocr"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model,name:account_invoice_google_document_ai.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model,name:account_invoice_google_document_ai.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields.selection,name:account_invoice_google_document_ai.selection__res_company__ocr_google_enabled__no_send
+msgid "Do not send invoices to google"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.res_config_settings_form_view
+msgid "Enable Google OCR for invoices"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields.selection,name:account_invoice_google_document_ai.selection__res_company__ocr_google_location__eu
+msgid "Europe"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model,name:account_invoice_google_document_ai.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.res_config_settings_form_view
+msgid "Location"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_company__ocr_google_authentication
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_config_settings__ocr_google_authentication
+msgid "Ocr Google Authentication"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_company__ocr_google_authentication_name
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_config_settings__ocr_google_authentication_name
+msgid "Ocr Google Authentication Name"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_company__ocr_google_enabled
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_config_settings__ocr_google_enabled
+msgid "Ocr Google Enabled"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_company__ocr_google_location
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_config_settings__ocr_google_location
+msgid "Ocr Google Location"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_company__ocr_google_processor
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_config_settings__ocr_google_processor
+msgid "Ocr Google Processor"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_company__ocr_google_project
+#: model:ir.model.fields,field_description:account_invoice_google_document_ai.field_res_config_settings__ocr_google_project
+msgid "Ocr Google Project"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields.selection,name:account_invoice_google_document_ai.selection__res_company__ocr_google_enabled__send_manual
+msgid "Only send invoices to google manually"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.res_config_settings_form_view
+msgid "Processor"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.res_config_settings_form_view
+msgid "Project"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields.selection,name:account_invoice_google_document_ai.selection__res_company__ocr_google_enabled__send_automatically
+msgid "Send invoices to google automatically"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model_terms:ir.ui.view,arch_db:account_invoice_google_document_ai.account_move_form_view
+msgid "Send to OCR"
+msgstr ""
+
+#. module: account_invoice_google_document_ai
+#: model:ir.model.fields.selection,name:account_invoice_google_document_ai.selection__res_company__ocr_google_location__us
+msgid "United States"
+msgstr ""

--- a/account_invoice_mass_sending/models/account_move.py
+++ b/account_invoice_mass_sending/models/account_move.py
@@ -13,7 +13,7 @@ class AccountInvoice(models.Model):
         "and it will prevent the sending of a duplicated mail.",
     )
 
-    def mass_sending(self, template=None):
+    def mass_sending(self, template=None, exclude_followers=False):
         """
         This method triggers the asynchronous sending for the selected
         invoices for which there is no asynchronous sending in progress
@@ -33,10 +33,13 @@ class AccountInvoice(models.Model):
                 invoice.with_delay(
                     description=description,
                     channel="root.account_invoice_mass_sending_channel",
-                )._send_invoice_individually(template=template)
+                )._send_invoice_individually(
+                    template=template,
+                    exclude_followers=exclude_followers,
+                )
         return invoices_to_send
 
-    def _send_invoice_individually(self, template=None):
+    def _send_invoice_individually(self, template=None, exclude_followers=False):
         self.ensure_one()
         res = self.action_invoice_sent()
         wiz_ctx = res["context"] or {}
@@ -48,7 +51,7 @@ class AccountInvoice(models.Model):
                 "active_ids": self.ids,
                 "active_id": self.id,
                 "discard_logo_check": True,
-                "account_invoice_mass_sending": True,
+                "exclude_followers": exclude_followers,
             }
         )
         wiz = self.env["account.invoice.send"].with_context(**wiz_ctx).create({})
@@ -67,3 +70,15 @@ class AccountInvoice(models.Model):
             }
         )
         return wiz.send_and_print_action()
+
+    def _notify_get_recipients(self, message, msg_vals, **kwargs):
+        recipients_data = super()._notify_get_recipients(message, msg_vals, **kwargs)
+        if not self.env.context.get("exclude_followers", False):
+            return recipients_data
+
+        msg_sudo = message.sudo()
+        pids = msg_vals.get("partner_ids", []) if msg_vals else msg_sudo.partner_ids.ids
+        filtered_recipients_data = [
+            recipient for recipient in recipients_data if recipient.get("id") in pids
+        ]
+        return filtered_recipients_data

--- a/account_invoice_mass_sending/tests/test_account_invoice_mass_sending.py
+++ b/account_invoice_mass_sending/tests/test_account_invoice_mass_sending.py
@@ -169,7 +169,7 @@ class TestAccountInvoiceMassSending(TransactionCase):
             trap.assert_jobs_count(1)
             trap.assert_enqueued_job(
                 self.first_eligible_invoice._send_invoice_individually,
-                kwargs={"template": self.mail_template_obj},
+                kwargs={"template": self.mail_template_obj, "exclude_followers": True},
             )
             trap.perform_enqueued_jobs()
             self.assertFalse(self.first_eligible_invoice.sending_in_progress)

--- a/account_invoice_mass_sending/wizards/account_invoice_send.py
+++ b/account_invoice_mass_sending/wizards/account_invoice_send.py
@@ -1,15 +1,24 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, models
+from odoo import _, fields, models
 
 
 class AccountInvoiceSend(models.TransientModel):
     _inherit = "account.invoice.send"
 
+    exclude_followers = fields.Boolean(
+        default=True,
+        help="If checked, the email will be send only to the invoice "
+        "partner, excluding followers."
+        "\nNote: This functionality only applies for mass sending.",
+    )
+
     def enqueue_invoices(self):
         active_ids = self._context.get("active_ids")
         invoices = self.env["account.move"].browse(active_ids)
-        invoices_to_send = invoices.mass_sending(self.template_id)
+        invoices_to_send = invoices.mass_sending(
+            template=self.template_id, exclude_followers=self.exclude_followers
+        )
         ineligible_invoices = invoices - invoices_to_send
         title = _("Invoices: Mass sending")
         msg = _(
@@ -48,12 +57,3 @@ class AccountInvoiceSend(models.TransientModel):
                 }
             )
         return notification
-
-    @api.onchange("invoice_ids")
-    def _compute_composition_mode(self):
-        """Force send as mass_mail although this module sends each invoice one by one
-        to avoid extra notificactions"""
-        if not self.env.context.get("account_invoice_mass_sending", False):
-            return super()._compute_composition_mode()
-        for wizard in self:
-            wizard.composer_id.composition_mode = "mass_mail"

--- a/account_invoice_mass_sending/wizards/account_invoice_send.xml
+++ b/account_invoice_mass_sending/wizards/account_invoice_send.xml
@@ -5,6 +5,9 @@
         <field name="model">account.invoice.send</field>
         <field name="inherit_id" ref="account.account_invoice_send_wizard_form" />
         <field name="arch" type="xml">
+            <field name="template_id" position="after">
+                <field name="exclude_followers" />
+            </field>
             <button name="send_and_print_action" position="before">
                 <button
                     name="enqueue_invoices"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,4 @@
+# google-cloud-documentai depends on google-auth, which depends on cryptography.
+# odoo relies on pyopenssl==20.0.1 which uses internal cryptography bindings
+# (X509_V_FLAG_CB_ISSUER_CHECK, X509_V_FLAG_NOTIFY_POLICY) removed in 37.0.0.
+cryptography<37


### PR DESCRIPTION
Fix broken email layout and missing follower notifications when sending invoices via Mass Send & Print.

The wizard was forcing composition_mode = mass_mail, which bypasses message_post() and therefore skips the standard email layout and follower notifications.

## Summary
- Add proper email layout (header, footer, company info) to mass invoice sending
- Notify invoice followers with separate emails (without access button)

## Before

https://github.com/user-attachments/assets/2b787f1b-ea83-4a6b-b9ce-c691ca8417c3

## After

https://github.com/user-attachments/assets/33dac3ac-476d-426e-a098-767d63661640

